### PR TITLE
geoip v1.6.12 ❄️ 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# see README
+# https://github.com/maxmind/geoip-api-c/blob/v1.6.12/README.md#from-source-on-unixlinux
+# the config.guess was old and this makes it updated
+./bootstrap
+
 ./configure --prefix=$PREFIX
 
 make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
     - make        # [unix]
     - m2-patch    # [win]
     - autoconf    # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "GeoIP" %}
-{% set version = "1.6.11" %}
-{% set sha256 = "b0e5a92200b5ab540d118983f7b7191caf4faf1ae879c44afa3ff2a2abcdb0f5" %}
+{% set version = "1.6.12" %}
 
 package:
   name: {{ name|lower }}
@@ -9,28 +8,34 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/maxmind/geoip-api-c/releases/download/v{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 1dfb748003c5e4b7fd56ba8c4cd786633d5d6f409547584f6910398389636f80
   patches:
     - Makefile.vc.patch  # [win]
 
 build:
-  number: 1000
+  number: 0
 
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - make        # [unix]
+    - m2-patch    # [win]
+    - autoconf    # [unix]
+    - automake    # [unix]
+    - libtool     # [unix]
+
   host:
   run:
 
 test:
   commands:
-    - if not exist %LIBRARY_INC%\\{{ name }}.h exit 1     # [win]
-    - if not exist %LIBRARY_LIB%\\{{ name }}.lib exit 1          # [win]
-    - if not exist %LIBRARY_BIN%\\{{ name }}.dll exit 1          # [win]
-    - test -f $PREFIX/include/{{ name }}.h                 # [unix]
-    - test -f $PREFIX/lib/lib{{ name }}.so                       # [linux]
-    - test -f $PREFIX/lib/lib{{ name }}.dylib                    # [osx]
-
+    - if not exist %LIBRARY_INC%\\{{ name }}.h exit 1    # [win]
+    - if not exist %LIBRARY_LIB%\\{{ name }}.lib exit 1  # [win]
+    - if not exist %LIBRARY_BIN%\\{{ name }}.dll exit 1  # [win]
+    - test -f $PREFIX/include/{{ name }}.h               # [unix]
+    - test -f $PREFIX/lib/lib{{ name }}.so               # [linux]
+    - test -f $PREFIX/lib/lib{{ name }}.dylib            # [osx]
 
 about:
   home: https://github.com/maxmind/geoip-api-c


### PR DESCRIPTION
[PKG-3091] geoip v1.6.12 ❄️ 

- links: 
    - upstream: https://github.com/maxmind/geoip-api-c/blob/v1.6.12/
    - conda-forge: https://github.com/conda-forge/geoip-feedstock
    - pypi: https://pypi.org/project/geoip2/
- destination channel: **Snowflake**
- list of changes:
    - recipe fixed / linter satisfied
    - version updated to `1.6.12`
    - `config.guess` update with `./bootstrap` as specified in [autotool-issues](https://github.com/maxmind/geoip-api-c/blob/v1.6.12/README.md#autotool-issues) because `osx-arm64` and `linux-aarch64` were not detected
    - `abs.yaml` for SF

Note: this package is deprecated in favor of `geoip2`:
    - https://blog.maxmind.com/2020/06/retirement-of-geoip-legacy-downloadable-databases-in-may-2022/
    - upstream: https://github.com/maxmind/GeoIP2-python
    - pypi: https://pypi.org/project/geoip2/

[PKG-3091]: https://anaconda.atlassian.net/browse/PKG-3091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ